### PR TITLE
Add qemu dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ docker buildx bake --load
 
 This will also build the example's Cartesi Machine containing the DApp's back-end logic.
 
+Note: if the example that you are running uses RISC-V architecture inside the Docker image, then you will also need QEMU dependencies.
+On linux Ubuntu these can be installed with:
+
+```shell
+sudo apt install -y qemu qemu-user-static
+```
+
+after which the supoprted buildkit platforms should include `linux/riscv64`.
+Confirm with:
+
+```shell
+docker buildx ls
+NAME/NODE DRIVER/ENDPOINT STATUS  BUILDKIT PLATFORMS
+default * docker                           
+  default default         running 23.0.5   linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
+```
+
 ## Running
 
 Each application can be executed in Production and Host modes, as explained below.


### PR DESCRIPTION
riscv platform is not supported by docker buildx on ubuntu install following the 

Otherwise this manifests in a pretty subtle error (see https://stackoverflow.com/a/73285704 ).

This is the error for troubleshooting future user installations:
```
=> [server machine-core 4/6] COPY shasumfile .                                                                                                                               0.0s
 => CANCELED [server machine-core 5/6] RUN while read DEP; do wget -O $DEP; done < dependencies                                                                              14.7s
 => [server 3/4] COPY . .                                                                                                                                                     6.6s
 => ERROR [console 4/4] RUN make                                                                                                                                              0.8s
------
 > [console 4/4] RUN make:
#0 0.490 exec /bin/sh: exec format error
------
Dockerfile:6
--------------------
   4 |     WORKDIR /opt/cartesi/dapp
   5 |     COPY . .
   6 | >>> RUN make
   7 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c make" did not complete successfully: exit code: 1
```

HTH!
