### PR TITLE
fix: Downgrade python library

### DIFF
--- a/auction/requirements.txt
+++ b/auction/requirements.txt
@@ -1,3 +1,4 @@
+cytoolz == 0.11.2
 requests == 2.23.0
 eth_abi == 4.0.0
 routes == 2.5.0

--- a/erc20/requirements.txt
+++ b/erc20/requirements.txt
@@ -1,2 +1,3 @@
+cytoolz == 0.11.2
 requests == 2.23.0
 eth_abi == 4.0.0


### PR DESCRIPTION
Newer version fails to intall in python 3.10