### PR TITLE
Feature/fix deploy testnet authority

### DIFF
--- a/build/docker-riscv/Dockerfile
+++ b/build/docker-riscv/Dockerfile
@@ -146,4 +146,4 @@ FROM busybox as machine-stage
 
 WORKDIR /var/opt/cartesi/machine-snapshots
 COPY --from=server-stage /var/opt/cartesi/machine-snapshots .
-CMD ["xxd", "-c", "256", "-p", "hash"]
+CMD ["xxd", "-c", "256", "-p", "0_0/hash"]

--- a/build/std-rootfs/Dockerfile
+++ b/build/std-rootfs/Dockerfile
@@ -174,4 +174,4 @@ FROM busybox as machine-stage
 WORKDIR /var/opt/cartesi/machine-snapshots
 COPY --from=server /var/opt/cartesi/machine-snapshots .
 
-CMD ["xxd", "-c", "256", "-p", "hash"]
+CMD ["xxd", "-c", "256", "-p", "0_0/hash"]

--- a/build/testnet-dapp-deployer/Dockerfile
+++ b/build/testnet-dapp-deployer/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker.io/docker/dockerfile:1.4
+FROM cartesi/rollups-cli:1.0.0-rc.2
+
+RUN apk update && apk add jq
+
+COPY deploy.sh .
+
+ENTRYPOINT [ "./deploy.sh" ]

--- a/build/testnet-dapp-deployer/deploy.sh
+++ b/build/testnet-dapp-deployer/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+export CONSENSUS_ADDRESS=$(cat /deployments/$NETWORK/rollups.json | jq -r '.contracts.Authority.address')
+
+echo "Deploying DApp \"$DAPP_NAME\" on network \"$NETWORK\" using consensus address \"$CONSENSUS_ADDRESS\"..."
+
+cartesi-rollups create \
+    --rpc "$RPC_URL" \
+    --mnemonic "$MNEMONIC" \
+    --templateHashFile /var/opt/cartesi/machine-snapshots/latest/hash \
+    --outputFile "/deployments/$NETWORK/$DAPP_NAME.json" \
+    --consensusAddress "$CONSENSUS_ADDRESS"

--- a/deploy-testnet.yml
+++ b/deploy-testnet.yml
@@ -7,26 +7,40 @@ services:
     volumes:
       - machine:/var/opt/cartesi/machine-snapshots
 
-  deployer:
-    image: ghcr.io/cartesi/rollups-cli:main
+  authority-deployer:
+    image: cartesi/rollups-hardhat:1.0.0-rc.2
+    command:
+      [
+        "deploy",
+        "--tags",
+        "Authority",
+        "--network",
+        "${NETWORK:?undefined NETWORK}",
+        "--export",
+        "/home/node/rollups.json",
+      ]
+    volumes:
+      - ./deployments/${NETWORK:?undefined NETWORK}:/home/node
+    environment:
+      - MNEMONIC=${MNEMONIC:?undefined MNEMONIC}
+      - RPC_URL=${RPC_URL:?undefined RPC_URL}
+
+  dapp-deployer:
+    build: ./build/testnet-dapp-deployer
     depends_on:
       machine:
         condition: service_started
-    command:
-      [
-        "create",
-        "--rpc",
-        "${RPC_URL:?undefined RPC_URL}",
-        "--mnemonic",
-        "${MNEMONIC:?undefined MNEMONIC}",
-        "--templateHashFile",
-        "/var/opt/cartesi/machine-snapshots/latest/hash",
-        "--outputFile",
-        "/deployments/${NETWORK:?undefined NETWORK}/${DAPP_NAME:?undefined DAPP_NAME}.json",
-      ]
+      authority-deployer:
+        condition: service_completed_successfully
     volumes:
       - machine:/var/opt/cartesi/machine-snapshots:ro
       - ./deployments:/deployments
+      - ./build:/build
+    environment:
+      - MNEMONIC=${MNEMONIC:?undefined MNEMONIC}
+      - NETWORK=${NETWORK:?undefined NETWORK}
+      - RPC_URL=${RPC_URL:?undefined RPC_URL}
+      - DAPP_NAME=${DAPP_NAME:?undefined DAPP_NAME}
 
 volumes:
   machine: {}

--- a/docker-compose-host-testnet.yml
+++ b/docker-compose-host-testnet.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   server_manager:
-    image: ghcr.io/cartesi/rollups-host-runner:main
+    image: cartesi/rollups-host-runner:1.0.0-rc.2
     ports:
       - "5004:5004"
     environment:

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   server_manager:
-    image: ghcr.io/cartesi/rollups-host-runner:main
+    image: cartesi/rollups-host-runner:1.0.0-rc.2
     ports:
       - "5004:5004"
     environment:

--- a/docker-compose-testnet.yml
+++ b/docker-compose-testnet.yml
@@ -10,7 +10,7 @@ x-credentials:
 
 services:
   dispatcher:
-    image: ghcr.io/cartesi/rollups-dispatcher:main
+    image: cartesi/rollups-dispatcher:1.0.0-rc.2
     restart: always
     depends_on:
       state_server:
@@ -34,7 +34,7 @@ services:
       - ./deployments:/deployments:ro
 
   state_server:
-    image: ghcr.io/cartesi/rollups-state-server:main
+    image: cartesi/rollups-state-server:1.0.0-rc.2
     restart: always
     healthcheck:
       test: [ "CMD-SHELL", "bash -c 'echo \"\" > /dev/tcp/127.0.0.1/50051;'" ]
@@ -50,7 +50,7 @@ services:
       BH_BLOCK_TIMEOUT: 120
 
   advance_runner:
-    image: ghcr.io/cartesi/rollups-advance-runner:main
+    image: cartesi/rollups-advance-runner:1.0.0-rc.2
     restart: always
     healthcheck:
       test: [ "CMD", "curl", "--fail", "localhost:8080/healthz" ]
@@ -89,7 +89,7 @@ services:
       - REMOTE_CARTESI_MACHINE_LOG_LEVEL=info
 
   inspect_server:
-    image: ghcr.io/cartesi/rollups-inspect-server:main
+    image: cartesi/rollups-inspect-server:1.0.0-rc.2
     restart: always
     ports:
       - "5005:5005"
@@ -103,7 +103,7 @@ services:
       SESSION_ID: default_rollups_id
 
   indexer:
-    image: ghcr.io/cartesi/rollups-indexer:main
+    image: cartesi/rollups-indexer:1.0.0-rc.2
     restart: always
     depends_on:
       database:
@@ -120,7 +120,7 @@ services:
       - ./deployments:/deployments:ro
 
   graphql_server:
-    image: ghcr.io/cartesi/rollups-graphql-server:main
+    image: cartesi/rollups-graphql-server:1.0.0-rc.2
     ports:
       - "4000:4000"
     depends_on:

--- a/docker-compose-testnet.yml
+++ b/docker-compose-testnet.yml
@@ -20,7 +20,7 @@ services:
     environment:
       RUST_LOG: info
       RD_DAPP_DEPLOYMENT_FILE: /deployments/${NETWORK:?undefined NETWORK}/${DAPP_NAME:?undefined DAPP_NAME}.json
-      RD_ROLLUPS_DEPLOYMENT_FILE: /opt/cartesi/share/deployments/${NETWORK:?undefined NETWORK}.json
+      RD_ROLLUPS_DEPLOYMENT_FILE: /deployments/${NETWORK:?undefined NETWORK}/rollups.json
       RD_EPOCH_DURATION: 86400
       SC_GRPC_ENDPOINT: http://state_server:50051
       SC_DEFAULT_CONFIRMATIONS: ${BLOCK_CONFIRMATIONS:?undefined BLOCK_CONFIRMATIONS}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-credentials:
 
 services:
   hardhat:
-    image: ghcr.io/cartesi/rollups-hardhat:main
+    image: cartesi/rollups-hardhat:1.0.0-rc.2
     command:
       [
         "node",
@@ -38,7 +38,7 @@ services:
       - ./deployments:/app/rollups/deployments
 
   dispatcher:
-    image: ghcr.io/cartesi/rollups-dispatcher:main
+    image: cartesi/rollups-dispatcher:1.0.0-rc.2
     restart: always
     depends_on:
       hardhat:
@@ -69,7 +69,7 @@ services:
       - ./deployments:/deployments:ro
 
   state_server:
-    image: ghcr.io/cartesi/rollups-state-server:main
+    image: cartesi/rollups-state-server:1.0.0-rc.2
     restart: always
     healthcheck:
       test: ["CMD-SHELL","bash -c 'echo \"\" > /dev/tcp/127.0.0.1/50051;'"]
@@ -88,7 +88,7 @@ services:
       BH_BLOCK_TIMEOUT: 8
 
   advance_runner:
-    image: ghcr.io/cartesi/rollups-advance-runner:main
+    image: cartesi/rollups-advance-runner:1.0.0-rc.2
     restart: always
     healthcheck:
       test: [ "CMD", "curl", "--fail", "localhost:8080/healthz" ]
@@ -131,7 +131,7 @@ services:
       - REMOTE_CARTESI_MACHINE_LOG_LEVEL=info
 
   deployer:
-    image: ghcr.io/cartesi/rollups-cli:main
+    image: cartesi/rollups-cli:1.0.0-rc.2
     restart: on-failure
     depends_on:
       hardhat:
@@ -188,7 +188,7 @@ services:
       ]
 
   inspect_server:
-    image: ghcr.io/cartesi/rollups-inspect-server:main
+    image: cartesi/rollups-inspect-server:1.0.0-rc.2
     restart: always
     ports:
       - "5005:5005"
@@ -202,7 +202,7 @@ services:
       SESSION_ID: default_rollups_id
 
   indexer:
-    image: ghcr.io/cartesi/rollups-indexer:main
+    image: cartesi/rollups-indexer:1.0.0-rc.2
     restart: always
     depends_on:
       database:
@@ -221,7 +221,7 @@ services:
       - ./deployments:/deployments:ro
 
   graphql_server:
-    image: ghcr.io/cartesi/rollups-graphql-server:main
+    image: cartesi/rollups-graphql-server:1.0.0-rc.2
     ports:
       - "4000:4000"
     depends_on:


### PR DESCRIPTION
Updates rollups images to 1.0.0-rc2 and updates/fixes the testnet deployment procedure to deploy an Authority instance owned by the user/deployer's account.

Closes #24 