### PR TITLE
fix: Make CI dapp build reproducible

### DIFF
--- a/.github/workflows/dapp-build.yml
+++ b/.github/workflows/dapp-build.yml
@@ -81,3 +81,4 @@ jobs:
                   set: |
                       *.cache-from=type=gha
                       *.cache-to=type=gha,mode=max
+                      *.args.NETWORK=sepolia


### PR DESCRIPTION
Currently the build is not specifying any network, which currently means "localhost" - which unfortunately is not reproducible at the moment. This commit changes it to a known supported testnet (sepolia), to make it reproducible. Note that in practice this means including deployment info for sepolia, which with deterministic deployments is the same for all networks.