### PR TITLE
chore: Bump version to 0.16.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] 2023-08-24
+
+### Added
+
+- Proper testnet execution config and instructions for Auction and ERC-20 DApps
+
+### Changed
+
+- Adapt all DApps to rollups 1.0.0
+- Remove DApp deployment information: there are no longer live deploys of any examples
+- Remove support for Goerli, which is no longer supported in rollups 1.0.0
+- Make CI builds reproducible (building for Sepolia)
+
 ## [0.15.1] 2023-07-04
 
 ### Changed
@@ -306,6 +319,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove machine-emulator-tools submodule
 - Remove openapi-interfaces submodule
 
+[0.16.0]: https://github.com/cartesi/rollups-examples/releases/tag/v0.16.0
 [0.15.1]: https://github.com/cartesi/rollups-examples/releases/tag/v0.15.1
 [0.15.0]: https://github.com/cartesi/rollups-examples/releases/tag/v0.15.0
 [0.14.0]: https://github.com/cartesi/rollups-examples/releases/tag/v0.14.0

--- a/echo-js/package.json
+++ b/echo-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartesi/echo-dapp",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Cartesi Echo JS DApp",
   "dependencies": {
     "ethers": "^5.5.4"

--- a/frontend-console/package.json
+++ b/frontend-console/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frontend-console",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "description": "Simple console front-end for Cartesi DApp",
     "author": "Danilo Tuler <danilo.tuler@cartesi.io>",
     "license": "Apache-2.0",

--- a/frontend-echo/package.json
+++ b/frontend-echo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frontend-echo",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "private": true,
     "dependencies": {
         "@apollo/client": "^3.7.13",


### PR DESCRIPTION
I decided to still call this 0.16.0 because I don't consider this examples-specific boilerplate (docker compose, template, etc) to be production-level.

When we move examples to Sunodo I think we could call it v1.0.